### PR TITLE
v3.0.2 - Update deprecated 'node-uuid' dependency to now depend on 'uuid'

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -19,7 +19,7 @@ var Auth0Strategy = require('passport-auth0');
 var cookieParser = require('cookie-parser');
 var session = require('express-session');
 // used for generating uuid for cookie secret
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 // for overriding options object
 var merge = require('merge');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-auth0-simple",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Simple authentication middleware for integrating Auth0 with Express-based applications.",
   "keywords": ["express", "auth0", "middleware", "authentication", "simple", "express4"],
   "main": "auth.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cookie-parser": "^1.4.3",
     "express-session": "^1.13.0",
     "merge": "^1.2.0",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.1",
     "passport": "^0.3.2",
     "passport-auth0": "^0.5.1"
   }


### PR DESCRIPTION
It appears this module was renamed (marked as DEPRECATED in npm install logs)